### PR TITLE
Allow new nodes to join existing cluster

### DIFF
--- a/lib/exhtml.ex
+++ b/lib/exhtml.ex
@@ -41,6 +41,19 @@ defmodule Exhtml do
 
 
   @doc """
+  Join an existing exhtml cluster.
+
+  * `node` - the node to connect
+  * `opts` - options to start this repo node, including:
+    * `data_dir` - where to store db datas, `./exhtml_contents` by default.
+    * `data_nodes` - which nodes are used to copy datas, `[node()]` by default.
+  """
+  def join_repo(node, opts) do
+    Exhtml.Host.join_repo(@name, node, opts)
+  end
+
+
+  @doc """
   Sets the content fetcher.
   A content fetcher is used when `Exhtml.update_content/1` is called.
   You can pass a function or module as content fetcher.

--- a/lib/exhtml.ex
+++ b/lib/exhtml.ex
@@ -32,6 +32,15 @@ defmodule Exhtml do
 
 
   @doc """
+  Start the repo engine. Before starting a repo, all actions will not be performed and
+  `{:error, :repo_not_started}` will be returned.
+  """
+  def start_repo(opts) do
+    Exhtml.Host.start_repo(@name, opts)
+  end
+
+
+  @doc """
   Sets the content fetcher.
   A content fetcher is used when `Exhtml.update_content/1` is called.
   You can pass a function or module as content fetcher.
@@ -41,6 +50,7 @@ defmodule Exhtml do
   ## Examples:
   
       iex> Exhtml.start []
+      ...> Exhtml.start_repo []
       ...> Exhtml.set_content_fetcher(fn slug -> "Hi, #\{slug}!" end)
       :ok
       iex> Exhtml.update_content(:foo)
@@ -62,6 +72,7 @@ defmodule Exhtml do
   ## Examples:
 
       iex> Exhtml.start []
+      ...> Exhtml.start_repo([])
       ...> Exhtml.set_content(:foo, :bar)
       ...> Exhtml.get_content(:foo)
       :bar
@@ -101,6 +112,7 @@ defmodule Exhtml do
   ## Examples:
 
       iex> Exhtml.start []
+      ...> Exhtml.start_repo([])
       ...> Exhtml.set_content(:foo, :bar)
       ...> Exhtml.get_content(:foo)
       :bar
@@ -122,6 +134,7 @@ defmodule Exhtml do
   ## Examples:
 
       iex> Exhtml.start []
+      ...> Exhtml.start_repo([])
       ...> Exhtml.set_content_fetcher fn slug -> "Hi, #\{slug}!" end
       ...> Exhtml.update_content :wuliu
       "Hi, wuliu!"

--- a/lib/exhtml/host.ex
+++ b/lib/exhtml/host.ex
@@ -32,6 +32,11 @@ defmodule Exhtml.Host do
   end
 
 
+  def join_repo(server, remote, opts) do
+    GenServer.call(server, {:join_repo, remote, opts})
+  end
+
+
   @doc """
   Gets html content from a host.
 
@@ -114,6 +119,7 @@ defmodule Exhtml.Host do
   ## Callbacks
 
   def init(opts) do
+    IO.puts "host: #{inspect opts}"
     {table, storage} = start_host_with_opts(opts)
     {:ok, {table, storage}}
   end
@@ -123,6 +129,14 @@ defmodule Exhtml.Host do
     state
     |> to_table_pid
     |> Exhtml.Table.start_repo(opts)
+    |> to_reply(state)
+  end
+
+
+  def handle_call({:join_repo, remote, opts}, _from, state) do
+    state
+    |> to_table_pid
+    |> Exhtml.Table.join_repo(remote, opts)
     |> to_reply(state)
   end
 
@@ -215,7 +229,7 @@ defmodule Exhtml.Host do
 
 
   defp set_content_to_table(nil, _, _), do: {:error, :not_running}
-  defp set_content_to_table(server, _slug, content = {:error, _}), do: content
+  defp set_content_to_table(_, _slug, content = {:error, _}), do: content
   defp set_content_to_table(server, slug, content) do
     Exhtml.Table.set(server, slug, content)
   end

--- a/lib/exhtml/host.ex
+++ b/lib/exhtml/host.ex
@@ -22,6 +22,16 @@ defmodule Exhtml.Host do
     GenServer.start_link(__MODULE__, opts, name: opts[:name])
   end
 
+
+  @doc """
+  Start the repo engine. Before starting a repo, all actions will not be performed and
+  `{:error, :repo_not_started}` will be returned.
+  """
+  def start_repo(server, opts) do
+    GenServer.call(server, {:start_repo, opts})
+  end
+
+
   @doc """
   Gets html content from a host.
 
@@ -106,6 +116,14 @@ defmodule Exhtml.Host do
   def init(opts) do
     {table, storage} = start_host_with_opts(opts)
     {:ok, {table, storage}}
+  end
+
+
+  def handle_call({:start_repo, opts}, _from, state) do
+    state
+    |> to_table_pid
+    |> Exhtml.Table.start_repo(opts)
+    |> to_reply(state)
   end
 
 

--- a/lib/exhtml/repo.ex
+++ b/lib/exhtml/repo.ex
@@ -54,6 +54,8 @@ defmodule Exhtml.Repo do
   end
 
 
+  ## callbacks
+
   def accept(new_node) do
     with _ <- :mnesia.change_config(:extra_db_nodes, [new_node]),
          _ <- :mnesia.add_table_copy(:schema, new_node, :disc_copies) do
@@ -68,15 +70,15 @@ defmodule Exhtml.Repo do
           :ok
 
         err ->
+          Logger.error(fn -> "error accpeting new node: #{new_node}, reason: #{inspect err}" end)
           err
       end
     end
   end
 
 
-  ## callbacks
-
   def init({:join, remote_node, opts}) do
+    Logger.debug(fn -> "joining existing repo #{inspect remote_node}, options: #{inspect opts}" end)
     with true <- Node.connect(remote_node),
          :ok <- start_empty_db(opts),
          :ok <- :rpc.call(remote_node, Exhtml.Repo, :accept, [node()]) do

--- a/lib/exhtml/repo.ex
+++ b/lib/exhtml/repo.ex
@@ -1,0 +1,155 @@
+defmodule Exhtml.Repo do
+
+  use GenServer
+  require Logger
+
+  @table_name_in_db :exhtml_contents
+  @default_data_dir "./exhtml_contents"
+
+  @doc """
+  Starts a mnesia repo.
+  * `opts` - options for starting the process:
+      * `data_dir` indicates which path the data will be persited in.
+      * `data_nodes` indicates which nodes will hold persisted data. Other nodes
+          will only hold data in memories.
+  Returns `{:ok, pid}` if succeed, `{:error, reason}` otherwise.
+  """
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+
+  def stop(repo) do
+    GenServer.stop(repo, :normal)
+  end
+
+
+  def join(remote_node) do
+    GenServer.start_link(__MODULE__, {:join, remote_node})
+  end
+
+
+  def get(repo, slug) do
+    GenServer.call(repo, {:get, slug})
+  end
+
+
+  def get_since(repo, slug, since) do
+    GenServer.call(repo, {:get_since, slug, since})
+  end
+
+
+  def set(repo, slug, content) do
+    GenServer.call(repo, {:set, slug, content})
+  end
+
+
+  def rm(repo, slug) do
+    GenServer.call(repo, {:rm, slug})
+  end
+
+
+  ## callbacks
+
+  def init({:join, remote_node}) do
+    with :ok <- Node.connect(remote_node),
+         {:ok, _} <- :rpc.call(remote_node, Exhtml.Repo, :accept, node()) do
+      :ok
+    end
+  end
+
+
+  def init(opts) do
+    start_db(
+      opts[:data_dir] || @default_data_dir,
+      opts[:data_nodes] || [node()]
+    )
+
+    {:ok, %{}}
+  end
+  
+
+  defp start_db(data_dir, nodes) do
+    File.mkdir_p data_dir
+
+    :mnesia |> :application.load
+    :mnesia |> :application.set_env(:dir, to_charlist(data_dir))
+    :mnesia |> :application.set_env(:auto_repair, true)
+
+    :mnesia.create_schema(nodes)
+    :mnesia.start
+    :mnesia.create_table @table_name_in_db, attributes: [:slug, :content], disc_copies: nodes
+
+    ret = :mnesia.wait_for_tables [@table_name_in_db], 5000
+
+    case ret do
+      {:timeout, _} ->
+        Logger.error fn -> "Error starting exhtml databse, timeout." end
+      {:error, reason} ->
+        Logger.error fn -> "Error starting exhtml databse, #{inspect reason}." end
+      _ ->
+        nil
+    end
+    ret
+  end
+
+  def handle_call({:get, slug}, _from, state) do
+    ret = slug
+      |> db_result
+      |> db_to_val
+
+    {:reply, ret, state}
+  end
+
+  def handle_call({:get_since, slug, since}, _from, state) do
+    val = slug
+      |> db_result
+      |> db_to_val_with_time
+
+    ret = case val do
+      nil             -> nil
+      {nil, nil}      -> nil
+      {content, nil}  -> {:ok, content}
+      {content, t}    -> to_content_since(content, t, since)
+      _               -> {:ok, val}
+    end
+
+    {:reply, ret, state}
+  end
+
+  def handle_call({:set, slug, content}, _from, state) do
+    {:atomic, _} = :mnesia.transaction(fn ->
+      :mnesia.write(@table_name_in_db, {@table_name_in_db, slug, {content, DateTime.utc_now}}, :write)
+    end)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:rm, slug}, _from, state) do
+    {:atomic, _} = :mnesia.transaction(fn ->
+      :mnesia.delete(@table_name_in_db, slug, :write)
+    end)
+    {:reply, :ok, state}
+  end
+
+  defp db_result(slug) do
+    @table_name_in_db |> :mnesia.dirty_read(slug) |> List.first
+  end
+
+  defp db_to_val(nil), do: nil
+  defp db_to_val({@table_name_in_db, _slug, {content, _t}}), do: content
+  defp db_to_val({@table_name_in_db, _slug, content}), do: content
+
+  defp db_to_val_with_time(nil), do: nil
+  defp db_to_val_with_time({@table_name_in_db, _slug, {content, mtime}}), do: {content, mtime}
+  defp db_to_val_with_time({@table_name_in_db, _slug, content}), do: {content, nil}
+
+  defp to_content_since(content, _, nil), do: {:ok, content}
+  defp to_content_since(content, t, since) do
+    case DateTime.compare(t, since) do
+      :lt -> :unchanged
+      _ -> {:ok, content}
+    end
+  end
+
+end

--- a/lib/exhtml/supervisor.ex
+++ b/lib/exhtml/supervisor.ex
@@ -21,7 +21,7 @@ defmodule Exhtml.Supervisor do
       worker(Exhtml.Stash, [registry_state])
     )
 
-Supervisor.start_child(
+    Supervisor.start_child(
       sup,
       worker(Exhtml.Host, [
         Keyword.put(opts, :name, :exhtml_host)

--- a/lib/exhtml/table.ex
+++ b/lib/exhtml/table.ex
@@ -16,26 +16,30 @@ defmodule Exhtml.Table do
 
   """
 
-  @table_name_in_db :exhtml_contents
-
   use GenServer
-  import Logger
+  alias Exhtml.Repo
 
   # APIs
 
   @doc """
   Starts a Exhtml.Table process.
-
   * `opts` - options for starting the process:
-      * `data_dir` indicates which path the data will be persited in.
-      * `data_nodes` indicates which nodes will hold persisted data. Other nodes
-          will only hold data in memories.
-
+    * `repo` - the pid of started Exhtml.Repo server.
+      If unprovided, all request to Exhtml.Table will return `{:error, :repo_not_started}`
   Returns `{:ok, pid}` if succeed, `{:error, reason}` otherwise.
   """
   @spec start_link([key: any]) :: {:ok, pid} | {:error, any}
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
+  end
+
+
+  @doc """
+  Start the repo engine. Before starting a repo, all actions will not be performed and
+  `{:error, :repo_not_started}` will be returned.
+  """
+  def start_repo(server, opts) do
+    GenServer.call(server, {:start_repo, opts})
   end
 
 
@@ -102,93 +106,39 @@ defmodule Exhtml.Table do
 
   @doc false
   def init(opts) do
-    start_db(
-      opts[:data_dir] || "./exhtml_contents",
-      opts[:data_nodes] || [Node.self]
-    )
-    {:ok, %{}}
-  end
+    case {opts[:repo], opts[:auto_start_repo]} do
+      {nil, false} ->
+        {:ok, %{repo: nil}}
 
-  defp start_db(data_dir, nodes) do
-    File.mkdir_p data_dir
+      {nil, _} ->
+        {:ok, repo} = Repo.start_link(opts)
+        {:ok, %{repo: repo}}
 
-    :mnesia |> :application.load
-    :mnesia |> :application.set_env(:dir, to_charlist(data_dir))
-    :mnesia |> :application.set_env(:auto_repair, true)
-
-    :mnesia.create_schema(nodes)
-    :mnesia.start
-    :mnesia.create_table @table_name_in_db, attributes: [:slug, :content], disc_copies: nodes
-
-    ret = :mnesia.wait_for_tables [@table_name_in_db], 5000
-
-    case ret do
-      {:timeout, _} ->
-        error "Error starting exhtml databse, timeout."
-      {:error, reason} ->
-        error "Error starting exhtml databse, #{inspect reason}."
-      _ ->
-        nil
-    end
-    ret
-  end
-
-  def handle_call({:get, slug}, _from, state) do
-    ret = slug
-      |> db_result
-      |> db_to_val
-
-    {:reply, ret, state}
-  end
-
-  def handle_call({:get_since, slug, since}, _from, state) do
-    val = slug
-      |> db_result
-      |> db_to_val_with_time
-
-    ret = case val do
-      nil             -> nil
-      {nil, nil}      -> nil
-      {content, nil}  -> {:ok, content}
-      {content, t}    -> to_content_since(content, t, since)
-      _               -> {:ok, val}
-    end
-
-    {:reply, ret, state}
-  end
-
-  def handle_call({:set, slug, content}, _from, state) do
-    {:atomic, _} = :mnesia.transaction(fn ->
-      :mnesia.write(@table_name_in_db, {@table_name_in_db, slug, {content, DateTime.utc_now}}, :write)
-    end)
-    {:reply, :ok, state}
-  end
-
-  def handle_call({:rm, slug}, _from, state) do
-    {:atomic, _} = :mnesia.transaction(fn ->
-      :mnesia.delete(@table_name_in_db, slug, :write)
-    end)
-    {:reply, :ok, state}
-  end
-
-  defp db_result(slug) do
-    @table_name_in_db |> :mnesia.dirty_read(slug) |> List.first
-  end
-
-  defp db_to_val(nil), do: nil
-  defp db_to_val({@table_name_in_db, _slug, {content, _t}}), do: content
-  defp db_to_val({@table_name_in_db, _slug, content}), do: content
-
-  defp db_to_val_with_time(nil), do: nil
-  defp db_to_val_with_time({@table_name_in_db, _slug, {content, mtime}}), do: {content, mtime}
-  defp db_to_val_with_time({@table_name_in_db, _slug, content}), do: {content, nil}
-
-  defp to_content_since(content, _, nil), do: {:ok, content}
-  defp to_content_since(content, t, since) do
-    case DateTime.compare(t, since) do
-      :lt -> :unchanged
-      _ -> {:ok, content}
+      {repo, _} when is_pid(repo) ->
+        {:ok, %{repo: repo}}
     end
   end
 
+  def handle_call({:start_repo, opts}, _from, state) do
+    {:ok, repo} = Repo.start_link(opts)
+    {:reply, :ok, Map.put(state, :repo, repo)}
+  end
+
+  def handle_call(_, _from, state = %{repo: nil}), do: {:reply, {:error, :repo_not_started}, state}
+
+  def handle_call({:get, slug}, _from, state = %{repo: repo}) do
+    {:reply, Repo.get(repo, slug), state}
+  end
+
+  def handle_call({:get_since, slug, since}, _from, state = %{repo: repo}) do
+    {:reply, Repo.get_since(repo, slug, since), state}
+  end
+
+  def handle_call({:set, slug, content}, _from, state = %{repo: repo}) do
+    {:reply, Repo.set(repo, slug, content), state}
+  end
+
+  def handle_call({:rm, slug}, _from, state = %{repo: repo}) do
+    {:reply, Repo.rm(repo, slug), state}
+  end
 end

--- a/lib/exhtml/table.ex
+++ b/lib/exhtml/table.ex
@@ -43,6 +43,11 @@ defmodule Exhtml.Table do
   end
 
 
+  def join_repo(server, remote, opts) do
+    GenServer.call(server, {:join_repo, remote, opts})
+  end
+
+
   @doc """
   Gets content of the slug from the store.
 
@@ -121,6 +126,12 @@ defmodule Exhtml.Table do
 
   def handle_call({:start_repo, opts}, _from, state) do
     {:ok, repo} = Repo.start_link(opts)
+    {:reply, :ok, Map.put(state, :repo, repo)}
+  end
+
+  def handle_call({:join_repo, remote, opts}, _from, state) do
+    {:ok, repo} = Repo.join(remote, opts)
+    IO.inspect Map.put(state, :repo, repo)
     {:reply, :ok, Map.put(state, :repo, repo)}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Exhtml.Mixfile do
   def project do
     [
       app: :exhtml,
-      version: "0.4.0-beta.1",
+      version: "0.4.0-beta.2",
       elixir: ">= 1.4.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,7 @@ defmodule Exhtml.Mixfile do
   def application do
     [
       applications: [:logger],
-      included_applications: [:mnesia],
-      mod: {Exhtml.App, []}
+      included_applications: [:mnesia]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Exhtml.Mixfile do
   def project do
     [
       app: :exhtml,
-      version: "0.3.1",
+      version: "0.4.0-beta1",
       elixir: ">= 1.4.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
@@ -25,7 +25,8 @@ defmodule Exhtml.Mixfile do
   def application do
     [
       applications: [:logger],
-      included_applications: [:mnesia]
+      included_applications: [:mnesia],
+      mod: {Exhtml.App, []}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Exhtml.Mixfile do
   def project do
     [
       app: :exhtml,
-      version: "0.4.0-beta1",
+      version: "0.4.0-beta.1",
       elixir: ">= 1.4.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,12 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []}}
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.10.1", "e85efaf2dd7054399083ab2c6a5199f6cb1805de1a5b00d9e8c5f07033407b1f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "inch_ex": {:hex, :inch_ex, "1.0.1", "1f0af1a83cec8e56f6fc91738a09c838e858db3d78ef5f2ec040fe4d5a62dabf", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}

--- a/test/exhtml/table_test.exs
+++ b/test/exhtml/table_test.exs
@@ -4,37 +4,64 @@ defmodule Exhtml.TableTest do
 
   doctest Exhtml.Table
 
-  setup do
-    Exhtml.Stash.start_link(%{}, %{})
-    {:ok, pid} = Exhtml.Table.start_link []
-    Exhtml.Table.rm(pid, "foo")
-    {:ok, %{pid: pid}}
+  describe "before all set" do
+
+    setup do
+      Exhtml.Stash.start_link(%{}, %{})
+      {:ok, pid} = Exhtml.Table.start_link auto_start_repo: false
+      Exhtml.Table.rm(pid, "foo")
+      {:ok, %{pid: pid}}
+    end
+
+    test "get nonexisting content", %{pid: pid} do
+      assert Exhtml.Table.get(pid, "nonexist") == {:error, :repo_not_started}
+    end
+
+    test "set content", %{pid: pid} do
+      assert Exhtml.Table.set(pid, "foo", "bar") == {:error, :repo_not_started}
+    end
+
+    test ".get_content_since of nonexist", %{pid: pid} do
+      assert Exhtml.Table.get_since(pid, "nonexist", nil) == {:error, :repo_not_started}
+    end
   end
 
-  test "get nonexisting content", %{pid: pid} do
-    assert Exhtml.Table.get(pid, "nonexist") == nil
-  end
+  describe "after all set" do
 
-  test "set content", %{pid: pid} do
-    :ok = Exhtml.Table.set(pid, "foo", "bar")
-    assert Exhtml.Table.get(pid, "foo") == "bar"
-  end
+    setup do
+      Exhtml.Stash.start_link(%{}, %{})
+      {:ok, pid} = Exhtml.Table.start_link auto_start_repo: false
+      Exhtml.Table.start_repo(pid, [])
 
-  test "set data_dir" do
-    assert Application.get_env(:mnesia, :dir) == './exhtml_contents'
-  end
+      {:ok, %{pid: pid}}
+    end
 
-  test ".get_content_since of nonexist", %{pid: pid} do
-    assert Exhtml.Table.get_since(pid, "nonexist", nil) == nil
-    assert Exhtml.Table.get_since(pid, "nonexist", DateTime.utc_now) == nil
-  end
+    test "get nonexisting content", %{pid: pid} do
+      assert Exhtml.Table.get(pid, "nonexist") == nil
+    end
 
-  test ".get_content_since of existing key", %{pid: pid} do
-    :ok = Exhtml.Table.set(pid, "foo", :bar)
+    test "set content", %{pid: pid} do
+      :ok = Exhtml.Table.set(pid, "foo", "bar")
+      assert Exhtml.Table.get(pid, "foo") == "bar"
+    end
 
-    assert Exhtml.Table.get_since(pid, "foo", nil) == {:ok, :bar}
-    assert Exhtml.Table.get_since(pid, "foo", DateTime.utc_now) == :unchanged
-    assert Exhtml.Table.get_since(pid, "foo", yesterday()) == {:ok, :bar}
+    test "set data_dir" do
+      assert Application.get_env(:mnesia, :dir) == './exhtml_contents'
+    end
+
+    test ".get_content_since of nonexist", %{pid: pid} do
+      assert Exhtml.Table.get_since(pid, "nonexist", nil) == nil
+      assert Exhtml.Table.get_since(pid, "nonexist", DateTime.utc_now) == nil
+    end
+
+    test ".get_content_since of existing key", %{pid: pid} do
+      :ok = Exhtml.Table.set(pid, "foo", :bar)
+
+      assert Exhtml.Table.get_since(pid, "foo", nil) == {:ok, :bar}
+      assert Exhtml.Table.get_since(pid, "foo", DateTime.utc_now) == :unchanged
+      assert Exhtml.Table.get_since(pid, "foo", yesterday()) == {:ok, :bar}
+    end
+
   end
 
 end

--- a/test/exhtml_test.exs
+++ b/test/exhtml_test.exs
@@ -2,7 +2,8 @@ defmodule ExhtmlTest do
   use ExUnit.Case
   doctest Exhtml
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  test "error is returned when interacting with exhtml without a repo started" do
+    Exhtml.start(auto_start_repo: false)
+    assert Exhtml.get_content(:foo) == {:error, :repo_not_started}
   end
 end


### PR DESCRIPTION
Formerly if a node needs to join the existing Exhtml cluster, which uses [Mnesia](http://erlang.org/doc/man/mnesia.html) underlayer, we use running configurations in `vm.args`. This is kind of static and hard to expand.

So I added a method `Exhtml.join/2` to allow new node to join, and `Exhtml.start auto_start_repo: false` to manually start repo before Exhtml is started.

Usage:

```elixir
# on a@node
# just start exhtml like before:
Exhtml.start([])

# on b@node
Exhtml.start(auto_start_repo: false)
Exhtml.join_repo(:"a@node", [])
```

That's it. You don't even need to connect node#a because `Exhtml.join` will try to connect for you.
